### PR TITLE
[Bug] Fix passing classical functions to the IR

### DIFF
--- a/qadence2_expressions/ircompiler.py
+++ b/qadence2_expressions/ircompiler.py
@@ -62,13 +62,14 @@ class IRBuilder(AbstractIRBuilder[Expression]):
             return AST.numeric(input_obj[0])
 
         if input_obj.is_symbol:
+            name = str(input_obj)
             size = input_obj.get("size", 1)
             trainable = input_obj.get("trainable", False)
             attrs = {k: v for k, v in input_obj.attrs.items() if k not in ["size", "trainable"]}
-            return AST.input_variable(input_obj[0], size, trainable, **attrs)
+            return AST.input_variable(name, size, trainable, **attrs)
 
         if input_obj.is_function:
-            name = input_obj[0]
+            name = str(input_obj[0])
             args = []
             for arg in input_obj[1:]:
                 args.append(IRBuilder.parse_sequence(arg))

--- a/tests/test_ir_compilation.py
+++ b/tests/test_ir_compilation.py
@@ -15,13 +15,14 @@ from qadence2_expressions import (
     RX,
     Z,
     compile_to_model,
+    cos,
     parameter,
 )
 
 
 def test_ir_compilation() -> None:
     theta = parameter("theta")
-    expr = Z() * RX(theta / 2)(0)
+    expr = Z() * RX(cos(theta / 2))(0)
     model = compile_to_model(expr)
 
     goal = Model(
@@ -30,7 +31,8 @@ def test_ir_compilation() -> None:
         instructions=[
             QuInstruct("z", Support.target_all()),
             Assign("%0", Call("mul", 0.5, Load("theta"))),
-            QuInstruct("rx", Support(target=(0,)), Load("%0")),
+            Assign("%1", Call("cos", Load("%0"))),
+            QuInstruct("rx", Support(target=(0,)), Load("%1")),
         ],
     )
 


### PR DESCRIPTION
Classical functions were passed to the IR as `Symbol('function_name')` instead of single string `funciton_name`. A proper fix should include extra validation from the IR side.
