### PR TITLE
[Bug] Fix failing test due to Environment resetting.

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -52,7 +52,3 @@ def test_add_and_get_qpu_directives() -> None:
 def test_add_and_get_settings() -> None:
     add_settings({"Some": "Settings"})
     assert get_settings() == {"Some": "Settings"}
-
-
-def test_reset_options() -> None:
-    reset_ir_options()

--- a/tests/test_ir_compilation.py
+++ b/tests/test_ir_compilation.py
@@ -20,10 +20,9 @@ from qadence2_expressions import (
     reset_ir_options,
 )
 
-reset_ir_options()
-
 
 def test_ir_compilation() -> None:
+    reset_ir_options()
     theta = parameter("theta")
     expr = Z() * RX(cos(theta / 2))(0)
     model = compile_to_model(expr)


### PR DESCRIPTION
The IR compilation test is failing due to the Environment not being reset properly from previous test.