### PR TITLE
Fix logarithm functiona and add square root function

### DIFF
--- a/qadence2_expressions/__init__.py
+++ b/qadence2_expressions/__init__.py
@@ -9,6 +9,7 @@ from .functions import (
     exp,
     log,
     sin,
+    sqrt,
 )
 from .ircompiler import compile_to_model
 from .operators import (
@@ -45,6 +46,7 @@ __all__ = [
     "RY",
     "RZ",
     "sin",
+    "sqrt",
     "X",
     "Xm",
     "Xp",

--- a/qadence2_expressions/functions.py
+++ b/qadence2_expressions/functions.py
@@ -21,4 +21,11 @@ def exp(x: Expression | complex | float | int) -> Expression:
 
 
 def log(x: Expression | complex | float | int) -> Expression:
-    return function("log", promote(x))
+    expr = function("log", promote(x))
+    # Logarithms of operators are also operators and need to be arranged as such.
+    return expr.as_quantum_operator()
+
+
+# Using square root as power makes symbolic simplifications easier.
+def sqrt(x: Expression | complex | float | int) -> Expression:
+    return promote(x) ** 0.5

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,6 +8,7 @@ from qadence2_expressions import (
     log,
     parameter,
     sin,
+    sqrt,
     unitary_hermitian_operator,
     variable,
 )
@@ -70,16 +71,39 @@ def test_exp() -> None:
 
 def test_log() -> None:
     expr = psi * X(4)
-    assert log(expr) == Expression(
-        Expression.Tag.FN,
-        Expression.symbol("log"),
-        Expression.mul(
-            Expression.symbol("psi", trainable=True),
-            Expression.quantum_operator(
-                Expression.symbol("X"),
-                Support(4),
-                is_hermitian=True,
-                is_unitary=True,
+    assert log(expr) == Expression.quantum_operator(
+        Expression(
+            Expression.Tag.FN,
+            Expression.symbol("log"),
+            Expression.mul(
+                Expression.symbol("psi", trainable=True),
+                Expression.quantum_operator(
+                    Expression.symbol("X"),
+                    Support(4),
+                    is_hermitian=True,
+                    is_unitary=True,
+                ),
             ),
         ),
+        Support(4),
+    )
+
+
+def test_sqrt() -> None:
+    expr = psi * X(4)
+    assert sqrt(expr) == Expression.quantum_operator(
+        Expression(
+            Expression.Tag.POW,
+            Expression.mul(
+                Expression.symbol("psi", trainable=True),
+                Expression.quantum_operator(
+                    Expression.symbol("X"),
+                    Support(4),
+                    is_hermitian=True,
+                    is_unitary=True,
+                ),
+            ),
+            Expression.value(0.5),
+        ),
+        Support(4),
     )


### PR DESCRIPTION
As the invert operation of the exponential, the logarithm function also needs to be promoted to an operator when applied to an operator. It enforces that `log(X(1))`, for instance, will be added to the `KRON` stack rather than the regular multiplication stack.

For the square root, simplifications are optimised to use `POWER`, so here, the `sqrt` is defined accordingly.
```python
sqrt(a * X(1)) == Power(a * X(1), 0.5)
```