### PR TITLE
[Feature] Add features to extend expressions functionalities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "qadence2-expressions"
 description = "Qadence 2 expressions consisting of symbolic expressions and blocks, i.e. quantum digital, analog, digital-analog and composite gates, together with their logic and engine."
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
 keywords = ["quantum"]

--- a/qadence2_expressions/__init__.py
+++ b/qadence2_expressions/__init__.py
@@ -14,10 +14,12 @@ from .functions import (
 from .ircompiler import compile_to_model
 from .operators import (
     CZ,
+    H,
     NOT,
     RX,
     RY,
     RZ,
+    SWAP,
     Z0,
     Z1,
     FreeEvolution,
@@ -37,6 +39,7 @@ __all__ = [
     "CZ",
     "exp",
     "FreeEvolution",
+    "H",
     "log",
     "NativeDrive",
     "NOT",
@@ -45,6 +48,7 @@ __all__ = [
     "RX",
     "RY",
     "RZ",
+    "SWAP",
     "sin",
     "sqrt",
     "X",

--- a/qadence2_expressions/core/__init__.py
+++ b/qadence2_expressions/core/__init__.py
@@ -32,6 +32,7 @@ from .environment import (
 )
 from .expression import Expression
 from .support import Support
+from .utils import Numeric
 
 __all__ = [
     "add_grid_options",
@@ -62,4 +63,5 @@ __all__ = [
     "unitary_hermitian_operator",
     "value",
     "variable",
+    "Numeric",
 ]

--- a/qadence2_expressions/core/constructors.py
+++ b/qadence2_expressions/core/constructors.py
@@ -5,13 +5,14 @@ from typing import Any, Callable
 from .environment import Environment
 from .expression import Expression
 from .support import Support
+from .utils import Numeric
 
 
-def value(x: complex | float | int) -> Expression:
+def value(x: Numeric) -> Expression:
     """Create a numerical expression from the value `x`.
 
     Args:
-        x (complex | float | int): Any numerical value.
+        x (Numeric): Any numerical value.
 
     Returns:
         Expression: An expression of type value.
@@ -29,11 +30,11 @@ def value(x: complex | float | int) -> Expression:
     return Expression.value(x)
 
 
-def promote(x: Expression | complex | float | int) -> Expression:
+def promote(x: Expression | Numeric) -> Expression:
     """Type cast inputs as value type expressions.
 
     Args:
-        x (Expression | complex | float | int): A valid expression or numerical value.
+        x (Expression | Numeric): A valid expression or numerical value.
          Numerical values are converted into `Value(x)` expressions.
 
     Returns:

--- a/qadence2_expressions/core/expression.py
+++ b/qadence2_expressions/core/expression.py
@@ -7,6 +7,7 @@ from re import sub
 from typing import Any
 
 from .support import Support
+from .utils import Numeric
 
 
 class Expression:
@@ -42,7 +43,7 @@ class Expression:
 
     # Constructors
     @classmethod
-    def value(cls, x: complex | float | int) -> Expression:
+    def value(cls, x: Numeric) -> Expression:
         """Promote a numerical value (complex, float, int) to an expression.
 
         Args:
@@ -378,11 +379,11 @@ class Expression:
 
     # Algebraic operations
     def __add__(self, other: object) -> Expression:
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
         # Promote numerial values to Expression.
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return self + Expression.value(other)
 
         # Addition identity: a + 0 = 0 + a = a
@@ -413,17 +414,17 @@ class Expression:
 
     def __radd__(self, other: object) -> Expression:
         # Promote numerical types to expression.
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return Expression.value(other) + self
 
         return NotImplemented
 
     def __mul__(self, other: object) -> Expression:
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
         # Promote numerical values to Expression.
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return self * Expression.value(other)
 
         # Null multiplication shortcut.
@@ -464,7 +465,7 @@ class Expression:
 
     def __rmul__(self, other: object) -> Expression:
         # Promote numerical types to expression.
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return Expression.value(other) * self
 
         return NotImplemented
@@ -472,10 +473,10 @@ class Expression:
     def __pow__(self, other: object) -> Expression:
         """Power involving quantum operators always promote expression to quantum operators."""
 
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return self ** Expression.value(other)
 
         # Numerical values are computed right away.
@@ -512,7 +513,7 @@ class Expression:
 
     def __rpow__(self, other: object) -> Expression:
         # Promote numerical types to expression.
-        if isinstance(other, complex | float | int):
+        if isinstance(other, Numeric):
             return Expression.value(other) ** self
 
         return NotImplemented
@@ -521,28 +522,28 @@ class Expression:
         return -1 * self
 
     def __sub__(self, other: object) -> Expression:
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
         return self + (-other)
 
     def __rsub__(self, other: object) -> Expression:
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
         return (-self) + other
 
     def __truediv__(self, other: object) -> Expression:
-        if not isinstance(other, Expression | complex | float | int):
+        if not isinstance(other, Expression | Numeric):
             return NotImplemented
 
         return self * (other**-1)
 
     def __rtruediv__(self, other: object) -> Expression:
-        if not isinstance(other, complex | float | int):
+        if not isinstance(other, Numeric):
             return NotImplemented
 
-        return other * (self**-1)
+        return other * (self**-1)  # type: ignore
 
     def __kron__(self, other: object) -> Expression:
         if not isinstance(other, Expression):
@@ -577,7 +578,11 @@ class Expression:
         return evaluate_kron(Expression.kron(self, other))
 
     def __matmul__(self, other: object) -> Expression:
-        warnings.warn("The `@` (`__matmul__`) operator will be deprecated. Use `*` instead.")
+        warnings.warn(
+            "The `@` (`__matmul__`) operator will be deprecated. Use `*` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.__kron__(other)
 
 

--- a/qadence2_expressions/core/utils.py
+++ b/qadence2_expressions/core/utils.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from typing import Union
+
+
+Numeric = Union[complex | float | int]

--- a/qadence2_expressions/core/utils.py
+++ b/qadence2_expressions/core/utils.py
@@ -1,6 +1,0 @@
-from __future__ import annotations
-
-from typing import Union
-
-
-Numeric = Union[complex | float | int]

--- a/qadence2_expressions/functions.py
+++ b/qadence2_expressions/functions.py
@@ -4,28 +4,29 @@ from qadence2_expressions import (
     Expression,
     function,
     promote,
+    Numeric,
 )
 
 
-def sin(x: Expression | complex | float | int) -> Expression:
+def sin(x: Expression | Numeric) -> Expression:
     return function("sin", promote(x))
 
 
-def cos(x: Expression | complex | float | int) -> Expression:
+def cos(x: Expression | Numeric) -> Expression:
     return function("cos", promote(x))
 
 
 # Exponential function as power.
-def exp(x: Expression | complex | float | int) -> Expression:
+def exp(x: Expression | Numeric) -> Expression:
     return Expression.symbol("E") ** promote(x)
 
 
-def log(x: Expression | complex | float | int) -> Expression:
+def log(x: Expression | Numeric) -> Expression:
     expr = function("log", promote(x))
     # Logarithms of operators are also operators and need to be arranged as such.
     return expr.as_quantum_operator()
 
 
 # Using square root as power makes symbolic simplifications easier.
-def sqrt(x: Expression | complex | float | int) -> Expression:
+def sqrt(x: Expression | Numeric) -> Expression:
     return promote(x) ** 0.5

--- a/qadence2_expressions/operators.py
+++ b/qadence2_expressions/operators.py
@@ -23,6 +23,10 @@ CZ = unitary_hermitian_operator("CZ")
 # Logic operators
 NOT = unitary_hermitian_operator("NOT")
 
+# Digital operators
+SWAP = unitary_hermitian_operator("SWAP")
+H = unitary_hermitian_operator("H")  # Hadamard gate
+
 # Default projectors
 Z0 = projector("Z", "0")
 Z1 = projector("Z", "1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,19 @@
-# use this file for configuring test fixtures and
-# functions common to every test
+from __future__ import annotations
+
+from typing import Callable
+import pytest
+
+from qadence2_expressions import (
+    CZ,
+    H,
+    NOT,
+    SWAP,
+    X,
+    Y,
+    Z,
+)
+
+
+@pytest.fixture
+def unitary_hermitian_operators() -> list[Callable]:
+    return [CZ, H, X, Y, Z, NOT, SWAP]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -103,10 +103,11 @@ def test_kron() -> None:
     term1 = Expression.kron(X(1), X(4))
     term2 = Expression.kron(X(2), X(3))
 
-    assert term1.__kron__(term2) == Expression.kron(X(1), X(2), X(3), X(4))
-    assert term2.__kron__(term1) == Expression.kron(X(1), X(2), X(3), X(4))
-    assert term1 @ term2 == Expression.kron(X(1), X(2), X(3), X(4))
-    assert term2 @ term1 == Expression.kron(X(1), X(2), X(3), X(4))
+    expected = Expression.kron(X(1), X(2), X(3), X(4))
+    assert term1.__kron__(term2) == expected
+    assert term2.__kron__(term1) == expected
+    assert term1 @ term2 == expected
+    assert term2 @ term1 == expected
 
 
 def test_commutativity() -> None:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from qadence2_expressions import (
     Expression,
     Support,
@@ -90,24 +92,26 @@ def test_division() -> None:
 def test_kron() -> None:
     X = unitary_hermitian_operator("X")
     term = Expression.kron(X(1), X(2), X(4))
+    expected = Expression.kron(X(1), X(2), X(3), X(4))
 
     # Push term from the right.
-    assert term.__kron__(X(3)) == Expression.kron(X(1), X(2), X(3), X(4))
-    assert term @ X(3) == Expression.kron(X(1), X(2), X(3), X(4))
+    assert term.__kron__(X(3)) == expected
+    assert term @ X(3) == expected
 
     # Push term from the left.
-    assert X(3).__kron__(term) == Expression.kron(X(1), X(2), X(3), X(4))
-    assert X(3) @ term == Expression.kron(X(1), X(2), X(3), X(4))
+    assert X(3).__kron__(term) == expected
+    assert X(3) @ term == expected
 
     # Join `kron` expressions.
     term1 = Expression.kron(X(1), X(4))
     term2 = Expression.kron(X(2), X(3))
 
-    expected = Expression.kron(X(1), X(2), X(3), X(4))
     assert term1.__kron__(term2) == expected
     assert term2.__kron__(term1) == expected
     assert term1 @ term2 == expected
     assert term2 @ term1 == expected
+    with pytest.deprecated_call():
+        term1 @ term2
 
 
 def test_commutativity() -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,39 +1,29 @@
 from __future__ import annotations
 
-import pytest
-from typing import Callable
-
 from qadence2_expressions import (
-    CZ,
-    H,
-    NOT,
     RX,
-    SWAP,
-    X,
-    Y,
-    Z,
     sqrt,
     value,
     variable,
 )
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_idempotency_unitary_hermitian_operators(operator: Callable) -> None:
-    assert operator() * operator() == value(1)
+def test_idempotency_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
+    for operator in unitary_hermitian_operators:
+        assert operator() * operator() == value(1)
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_int_power_unitary_hermitian_operators(operator: Callable) -> None:
-    assert operator() ** 2 == value(1)
-    assert operator() ** 3 == operator()
+def test_int_power_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
+    for operator in unitary_hermitian_operators:
+        assert operator() ** 2 == value(1)
+        assert operator() ** 3 == operator()
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_fractional_power_unitary_hermitian_operators(operator: Callable) -> None:
-    # Simplify only acting on same subspace.
-    assert sqrt(operator()) * sqrt(operator()) == operator()
-    assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
+def test_fractional_power_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
+    for operator in unitary_hermitian_operators:
+        # Simplify only acting on same subspace.
+        assert sqrt(operator()) * sqrt(operator()) == operator()
+        assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
 
 
 def test_parametric_opertor() -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,39 @@
 from __future__ import annotations
 
+import pytest
+from typing import Callable
+
 from qadence2_expressions import (
+    CZ,
+    H,
+    NOT,
     RX,
+    SWAP,
+    X,
+    Y,
+    Z,
+    sqrt,
+    value,
     variable,
 )
+
+
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_idempotency_unitary_hermitian_operators(operator: Callable) -> None:
+    assert operator() * operator() == value(1)
+
+
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_int_power_unitary_hermitian_operators(operator: Callable) -> None:
+    assert operator() ** 2 == value(1)
+    assert operator() ** 3 == operator()
+
+
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_fractional_power_unitary_hermitian_operators(operator: Callable) -> None:
+    # Simplify only acting on same subspace.
+    assert sqrt(operator()) * sqrt(operator()) == operator()
+    assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
 
 
 def test_parametric_opertor() -> None:


### PR DESCRIPTION
This PR aimed to accomplish the following

- [x] (**NO LONGER VALID**) extend arithmetic operations between `Expression` and numeric values, such as int, float, complex, to also external packages such as `numpy` and `torch` (currently only native python numeric types supported)
- [x] remove `withrepr` decorator. It caused issues for not supporting kwargs, such as the case of `NativeDrive` with its `instruction_name` kwarg
- [x] include `__matmul__` (`@`) operation as a kron operation on `Expression`