### PR TITLE
[Feature] Add the Hadamard and SWAP gates to the Hermitian operators list

### DIFF
--- a/qadence2_expressions/__init__.py
+++ b/qadence2_expressions/__init__.py
@@ -14,10 +14,12 @@ from .functions import (
 from .ircompiler import compile_to_model
 from .operators import (
     CZ,
+    H,
     NOT,
     RX,
     RY,
     RZ,
+    SWAP,
     Z0,
     Z1,
     FreeEvolution,
@@ -37,6 +39,7 @@ __all__ = [
     "CZ",
     "exp",
     "FreeEvolution",
+    "H",
     "log",
     "NativeDrive",
     "NOT",
@@ -45,6 +48,7 @@ __all__ = [
     "RX",
     "RY",
     "RZ",
+    "SWAP",
     "sin",
     "sqrt",
     "X",

--- a/qadence2_expressions/core/expression.py
+++ b/qadence2_expressions/core/expression.py
@@ -804,6 +804,16 @@ def evaluate_kronop(lhs: Expression, rhs: Expression) -> Expression:
                 else Expression.quantum_operator(res, lhs[1], **lhs.attrs)
             )
 
+        # Simplify the multiplication of unitary Hermitian operators with fractional
+        # power, e.g., `√X() * √X() == X()`.
+        if (
+            lhs[0].is_power
+            and rhs[0].is_power
+            and lhs[0][0] == rhs[0][0]  # both are the same operator
+            and (lhs[0][0].get("is_hermitian") and lhs[0][0].get("is_unitary"))
+        ):
+            return lhs[0][0] ** (lhs[0][1] + rhs[0][1])  # type: ignore
+
     # Order the operators by subspace.
     if lhs.subspace < rhs.subspace or lhs.subspace.overlap_with(  # type: ignore
         rhs.subspace  # type: ignore

--- a/qadence2_expressions/core/expression.py
+++ b/qadence2_expressions/core/expression.py
@@ -489,6 +489,17 @@ class Expression:
         if other.is_one:
             return self
 
+        if (
+            self.is_quantum_operator
+            and self.get("is_hermitian")
+            and self.get("is_unitary")
+            and isinstance(other, Expression)
+            and other.is_value
+            and other[0] == int(other[0])
+        ):
+            power = int(other[0]) % 2
+            return self if power == 1 else Expression.one()
+
         # Power of power is an simple operation and can be evaluated here.
         # Whenever a quantum operator is present, the expression is promoted to
         # a quantum operator.

--- a/qadence2_expressions/operators.py
+++ b/qadence2_expressions/operators.py
@@ -23,6 +23,10 @@ CZ = unitary_hermitian_operator("CZ")
 # Logic operators
 NOT = unitary_hermitian_operator("NOT")
 
+# Digital operators
+SWAP = unitary_hermitian_operator("SWAP")
+H = unitary_hermitian_operator("H")  # Hadamard gate
+
 # Default projectors
 Z0 = projector("Z", "0")
 Z1 = projector("Z", "1")

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -14,7 +14,7 @@ from qadence2_expressions import (
 )
 
 
-def test_unitary_hermitian_operators() -> None:
+def test_idempotency_unitary_hermitian_operators() -> None:
     assert H() * H() == value(1)
     assert X() * X() == value(1)
     assert Y() * Y() == value(1)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+from typing import Callable
+
 from qadence2_expressions import (
     CZ,
     H,
@@ -14,14 +17,15 @@ from qadence2_expressions import (
 )
 
 
-def test_idempotency_unitary_hermitian_operators() -> None:
-    assert H() * H() == value(1)
-    assert X() * X() == value(1)
-    assert Y() * Y() == value(1)
-    assert Z() * Z() == value(1)
-    assert CZ() * CZ() == value(1)
-    assert NOT() * NOT() == value(1)
-    assert SWAP() * SWAP() == value(1)
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_idempotency_unitary_hermitian_operators(operator: Callable) -> None:
+    assert operator() * operator() == value(1)
+
+
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_power_unitary_hermitian_operators(operator: Callable) -> None:
+    assert operator() ** 2 == value(1)
+    assert operator() ** 3 == operator()
 
 
 def test_parametric_opertor() -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -12,6 +12,7 @@ from qadence2_expressions import (
     X,
     Y,
     Z,
+    sqrt,
     value,
     variable,
 )
@@ -23,9 +24,16 @@ def test_idempotency_unitary_hermitian_operators(operator: Callable) -> None:
 
 
 @pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_power_unitary_hermitian_operators(operator: Callable) -> None:
+def test_int_power_unitary_hermitian_operators(operator: Callable) -> None:
     assert operator() ** 2 == value(1)
     assert operator() ** 3 == operator()
+
+
+@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
+def test_fractional_power_unitary_hermitian_operators(operator: Callable) -> None:
+    # Simplify only acting on same subspace.
+    assert sqrt(operator()) * sqrt(operator()) == operator()
+    assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
 
 
 def test_parametric_opertor() -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,27 @@
 from __future__ import annotations
 
 from qadence2_expressions import (
+    CZ,
+    H,
+    NOT,
     RX,
+    SWAP,
+    X,
+    Y,
+    Z,
+    value,
     variable,
 )
+
+
+def test_unitary_hermitian_operators() -> None:
+    assert H() * H() == value(1)
+    assert X() * X() == value(1)
+    assert Y() * Y() == value(1)
+    assert Z() * Z() == value(1)
+    assert CZ() * CZ() == value(1)
+    assert NOT() * NOT() == value(1)
+    assert SWAP() * SWAP() == value(1)
 
 
 def test_parametric_opertor() -> None:


### PR DESCRIPTION
The current list of basic operators lacks the `H` Hadamard and `SWAP` gates. Although these can be composed of more basic gates, having them as atomic elements can help simplify expression.

For instance, a `SWAP(1, 2)` can be expressed either as `NOT(target=(1, ), control=(2,)) * NOT(target=(2, ), control=(1,)) * NOT(target=(1, ), control=(2,))` or `NOT(target=(2, ), control=(1,)) * NOT(target=(1, ), control=(2,)) * NOT(target=(2, ), control=(1,))`.

Since the choice may affect the expression simplification, having the `SWAP` as an atomic element allows one to choose the definition that best reduces the terms.