### PR TITLE
[Hot fix] Move the list of Herminitian operator to the conftest as fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,19 @@
-# use this file for configuring test fixtures and
-# functions common to every test
+from __future__ import annotations
+
+from typing import List, Callable
+import pytest
+
+from qadence2_expressions import (
+    CZ,
+    H,
+    NOT,
+    SWAP,
+    X,
+    Y,
+    Z,
+)
+
+
+@pytest.fixture
+def unitary_hermitian_operators() -> List[Callable]:
+    return [CZ, H, X, Y, Z, NOT, SWAP]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Callable
+from typing import Callable
 import pytest
 
 from qadence2_expressions import (
@@ -15,5 +15,5 @@ from qadence2_expressions import (
 
 
 @pytest.fixture
-def unitary_hermitian_operators() -> List[Callable]:
+def unitary_hermitian_operators() -> list[Callable]:
     return [CZ, H, X, Y, Z, NOT, SWAP]

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 from qadence2_expressions import (
     RX,
     sqrt,
@@ -10,18 +8,18 @@ from qadence2_expressions import (
 )
 
 
-def test_idempotency_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+def test_idempotency_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
     for operator in unitary_hermitian_operators:
         assert operator() * operator() == value(1)
 
 
-def test_int_power_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+def test_int_power_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
     for operator in unitary_hermitian_operators:
         assert operator() ** 2 == value(1)
         assert operator() ** 3 == operator()
 
 
-def test_fractional_power_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+def test_fractional_power_unitary_hermitian_operators(unitary_hermitian_operators: list) -> None:
     for operator in unitary_hermitian_operators:
         # Simplify only acting on same subspace.
         assert sqrt(operator()) * sqrt(operator()) == operator()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,39 +1,31 @@
 from __future__ import annotations
 
-import pytest
-from typing import Callable
+from typing import List
 
 from qadence2_expressions import (
-    CZ,
-    H,
-    NOT,
     RX,
-    SWAP,
-    X,
-    Y,
-    Z,
     sqrt,
     value,
     variable,
 )
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_idempotency_unitary_hermitian_operators(operator: Callable) -> None:
-    assert operator() * operator() == value(1)
+def test_idempotency_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+    for operator in unitary_hermitian_operators:
+        assert operator() * operator() == value(1)
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_int_power_unitary_hermitian_operators(operator: Callable) -> None:
-    assert operator() ** 2 == value(1)
-    assert operator() ** 3 == operator()
+def test_int_power_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+    for operator in unitary_hermitian_operators:
+        assert operator() ** 2 == value(1)
+        assert operator() ** 3 == operator()
 
 
-@pytest.mark.parametrize("operator", [CZ, H, X, Y, Z, NOT, SWAP])
-def test_fractional_power_unitary_hermitian_operators(operator: Callable) -> None:
-    # Simplify only acting on same subspace.
-    assert sqrt(operator()) * sqrt(operator()) == operator()
-    assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
+def test_fractional_power_unitary_hermitian_operators(unitary_hermitian_operators: List) -> None:
+    for operator in unitary_hermitian_operators:
+        # Simplify only acting on same subspace.
+        assert sqrt(operator()) * sqrt(operator()) == operator()
+        assert sqrt(operator(0)) * sqrt(operator(1)) == sqrt(operator(0)) * sqrt(operator(1))
 
 
 def test_parametric_opertor() -> None:


### PR DESCRIPTION
Clean the `test_idempotency_unitary_hermitian_operators`, `test_int_power_unitary_hermitian_operators` and `test_fractional_power_unitary_hermitian_operators` by move the parameter list to the conftest as a fixture.
